### PR TITLE
Fix 재고 등록, 추가 시 상품 등록자만 수정할 수 있게 변경

### DIFF
--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/StockController.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/StockController.java
@@ -12,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+import site.ng_archive.ecom_common.auth.Role;
+import site.ng_archive.ecom_common.auth.UserContext;
+import site.ng_archive.ecom_common.auth.aspect.LoginUser;
+import site.ng_archive.ecom_common.auth.aspect.RequireRoles;
 import site.ng_archive.ecom_stock.domain.stock.dto.AddStockRequest;
 import site.ng_archive.ecom_stock.domain.stock.dto.CancelStockRequest;
 import site.ng_archive.ecom_stock.domain.stock.dto.CreateStockRequest;
@@ -32,9 +36,11 @@ public class StockController {
             .map(ReadStockResponse::from);
     }
 
+    @RequireRoles
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{productId}/stock")
     public Mono<CreateStockResponse> createStock(
+        @LoginUser UserContext user,
         @PathVariable Long productId,
         @Valid @RequestBody CreateStockRequest request
     ) {
@@ -42,7 +48,7 @@ public class StockController {
             return Mono.error(new IllegalArgumentException("stock.invalid.productid"));
         }
 
-        return stockService.createStock(request.toCommand())
+        return stockService.createStock(request.toCommand(user.id()))
             .map(CreateStockResponse::from);
     }
 
@@ -59,9 +65,11 @@ public class StockController {
         return stockService.deductStock(request.toCommand()).then();
     }
 
+    @RequireRoles
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/{productId}/stock/add")
     public Mono<Void> addStock(
+        @LoginUser UserContext user,
         @PathVariable Long productId,
         @Valid @RequestBody AddStockRequest request
     ) {
@@ -69,7 +77,7 @@ public class StockController {
             return Mono.error(new IllegalArgumentException("stock.invalid.productid"));
         }
 
-        return stockService.addStock(request.toCommand()).then();
+        return stockService.addStock(request.toCommand(user.id())).then();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/StockService.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/StockService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
+import site.ng_archive.ecom_common.auth.exception.ForbiddenException;
 import site.ng_archive.ecom_common.handler.EntityNotFoundException;
 import site.ng_archive.ecom_stock.domain.stock.dto.AddStockCommand;
 import site.ng_archive.ecom_stock.domain.stock.dto.CancelStockCommand;
@@ -29,7 +30,9 @@ public class StockService {
     @Transactional
     public Mono<Stock> createStock(CreateStockCommand command) {
         return productRequester.getProduct(command.productId())
-            .switchIfEmpty(Mono.defer(() -> Mono.error(new EntityNotFoundException("product.notfound"))))
+            .switchIfEmpty(Mono.error(() -> new EntityNotFoundException("product.notfound")))
+            .filter(product -> command.memberId().equals(product.memberId()))
+            .switchIfEmpty(Mono.error(() -> new ForbiddenException("stock.forbidden")))
             .flatMap(product -> stockRepository.save(command.toEntity()))
             .onErrorMap(DuplicateKeyException.class, e -> new IllegalArgumentException("stock.already.exists"))
             .flatMap(stock -> stockHistoryRepository.save(StockHistory.create(stock))
@@ -62,9 +65,11 @@ public class StockService {
     @Transactional
     public Mono<Stock> addStock(AddStockCommand command) {
         return productRequester.getProduct(command.productId())
-            .switchIfEmpty(Mono.defer(() -> Mono.error(new EntityNotFoundException("product.notfound"))))
+            .switchIfEmpty(Mono.error(() -> new EntityNotFoundException("product.notfound")))
+            .filter(product -> command.memberId().equals(product.memberId()))
+            .switchIfEmpty(Mono.error(() -> new ForbiddenException("stock.forbidden")))
             .flatMap(product -> stockRepository.findByProductIdForUpdate(command.productId()))
-            .switchIfEmpty(Mono.defer(() -> Mono.error(new EntityNotFoundException("stock.notfound"))))
+            .switchIfEmpty(Mono.error(() -> new EntityNotFoundException("stock.notfound")))
             .flatMap(stock -> stockRepository.save(stock.add(command.quantity())))
             .flatMap(added -> stockHistoryRepository
                 .save(StockHistory.createAdded(added, command.quantity()))

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/AddStockCommand.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/AddStockCommand.java
@@ -1,4 +1,4 @@
 package site.ng_archive.ecom_stock.domain.stock.dto;
 
-public record AddStockCommand(Long productId, Long quantity) {
+public record AddStockCommand(Long productId, Long quantity, Long memberId) {
 }

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/AddStockRequest.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/AddStockRequest.java
@@ -3,7 +3,7 @@ package site.ng_archive.ecom_stock.domain.stock.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record AddStockRequest(@NotNull Long productId, @NotNull Long quantity) {
-    public AddStockCommand toCommand() {
-        return new AddStockCommand(productId, quantity);
+    public AddStockCommand toCommand(Long memberId) {
+        return new AddStockCommand(productId, quantity, memberId);
     }
 }

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/CreateStockCommand.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/CreateStockCommand.java
@@ -2,7 +2,7 @@ package site.ng_archive.ecom_stock.domain.stock.dto;
 
 import site.ng_archive.ecom_stock.domain.stock.Stock;
 
-public record CreateStockCommand(Long productId, Long quantity) {
+public record CreateStockCommand(Long productId, Long quantity, Long memberId) {
     public Stock toEntity() {
         return new Stock(null, productId, quantity);
     }

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/CreateStockRequest.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/CreateStockRequest.java
@@ -3,7 +3,7 @@ package site.ng_archive.ecom_stock.domain.stock.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateStockRequest(@NotNull Long productId, @NotNull Long quantity) {
-    public CreateStockCommand toCommand() {
-        return new CreateStockCommand(productId, quantity);
+    public CreateStockCommand toCommand(Long memberId) {
+        return new CreateStockCommand(productId, quantity, memberId);
     }
 }

--- a/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/ProductResponse.java
+++ b/src/main/java/site/ng_archive/ecom_stock/domain/stock/dto/ProductResponse.java
@@ -1,4 +1,4 @@
 package site.ng_archive.ecom_stock.domain.stock.dto;
 
-public record ProductResponse(Long id, String name, Long price) {
+public record ProductResponse(Long id, String name, Long price, Long memberId) {
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -18,4 +18,5 @@ stock.already.exists=해당 상품이 이미 재고정보가 존재합니다.
 stock.invalid.stockid=올바르지 않은 정보입니다.
 stock.invalid.type=타입이 올바르지 않습니다.
 stock.history.notfound=재고 변동 내역을 찾을 수 없습니다.
+stock.forbidden=해당 상품에 대한 재고 관리 권한이 없습니다.
 product.notfound=상품 데이터가 존재하지 않습니다.

--- a/src/test/java/site/ng_archive/ecom_stock/domain/stock/StockControllerTest.java
+++ b/src/test/java/site/ng_archive/ecom_stock/domain/stock/StockControllerTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
+import site.ng_archive.ecom_common.auth.Role;
+import site.ng_archive.ecom_common.auth.UserContext;
+import site.ng_archive.ecom_common.auth.token.TokenUtil;
 import site.ng_archive.ecom_common.config.AcceptedTest;
 import site.ng_archive.ecom_common.error.ErrorResponse;
 import site.ng_archive.ecom_stock.EcomStockApplication;
@@ -63,8 +66,9 @@ class StockControllerTest extends AcceptedTest {
     void 재고단건조회() {
 
         Long productId = 1L;
-        stockTestTemplate.createStock(productId, 100L);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+        stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
 
         ReadStockResponse response =
             given()
@@ -98,12 +102,15 @@ class StockControllerTest extends AcceptedTest {
     void 재고생성() {
 
         Long productId = 1L;
+        Long memberId = 10L;
         CreateStockRequest createStockRequest = new CreateStockRequest(productId, 100L);
-        stockTestTemplate.createProductResponse(productId);
+        stockTestTemplate.createProductResponse(productId, memberId);
+        String token = createTestJwtToken(memberId, Role.ROLES.SELLER);
 
         CreateStockResponse response =
             given()
                 .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
                 .pathParam("productId", productId)
                 .body(createStockRequest)
                 .consumeWith(document(
@@ -146,10 +153,13 @@ class StockControllerTest extends AcceptedTest {
 
         Long invalidProductId = 2L;
         CreateStockRequest createStockRequest = new CreateStockRequest(1L, 100L);
+        Long memberId = 10L;
+        String token = createTestJwtToken(memberId, Role.ROLES.SELLER);
 
         ErrorResponse response =
             given()
                 .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
                 .pathParam("productId", invalidProductId)
                 .body(createStockRequest)
                 .consumeWith(document(
@@ -182,13 +192,59 @@ class StockControllerTest extends AcceptedTest {
     }
 
     @Test
+    void 재고생성_소유자아님() {
+
+        Long productId = 1L;
+        Long memberId = 10L;
+        Long forbiddenMemberId = 20L;
+        CreateStockRequest createStockRequest = new CreateStockRequest(productId, 100L);
+        stockTestTemplate.createProductResponse(productId, forbiddenMemberId);
+        String token = createTestJwtToken(memberId, Role.ROLES.SELLER);
+
+        ErrorResponse response =
+            given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
+                .pathParam("productId", productId)
+                .body(createStockRequest)
+                .consumeWith(document(
+                    info()
+                        .tag("Stock")
+                        .summary("재고 생성")
+                        .description("상품 ID를 사용하여 재고를 생성합니다.")
+                        .pathParameters(
+                            parameterWithName("productId").description("상품 아이디")
+                        )
+                        .requestFields(
+                            field(CreateStockRequest.class, "productId", "상품 ID"),
+                            field(CreateStockRequest.class, "quantity", "재고 수량")
+                        )
+                        .responseFields(
+                            field(ErrorResponse.class, "errorCode", "오류 코드"),
+                            field(ErrorResponse.class, "message", "오류 메시지")
+                        )
+                ))
+                .post("/{productId}/stock")
+                .then()
+                .status(HttpStatus.FORBIDDEN)
+                .log().all()
+                .extract().body().as(ErrorResponse.class);
+
+        Assertions.assertThat(response.errorCode()).isEqualTo("stock.forbidden");
+        Assertions.assertThat(response.message()).isEqualTo("해당 상품에 대한 재고 관리 권한이 없습니다.");
+        Stock stock = stockRepository.findByProductId(createStockRequest.productId()).block();
+        Assertions.assertThat(stock).isNull();
+    }
+
+    @Test
     void 재고차감() {
 
         Long productId = 1L;
         Long orderId = 1L;
         Long deductQuantity = 30L;
-        Stock stock = stockTestTemplate.createStock(productId, 100L);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+        Stock stock = stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
         DeductStockRequest request = new DeductStockRequest(productId, orderId, deductQuantity);
 
         given()
@@ -233,8 +289,9 @@ class StockControllerTest extends AcceptedTest {
         Long productId = 1L;
         Long orderId = 1L;
         Long deductQuantity = 11L;
-        Stock stock = stockTestTemplate.createStock(productId, 10L);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+        Stock stock = stockTestTemplate.createStock(productId, 10L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
         DeductStockRequest request = new DeductStockRequest(productId, orderId, deductQuantity);
 
         ErrorResponse response =
@@ -275,8 +332,9 @@ class StockControllerTest extends AcceptedTest {
 
         long productId = 1L;
         int threadCount = 10;
+        Long memberId = 10L;
 
-        stockTestTemplate.createStock(productId, (long) threadCount);
+        stockTestTemplate.createStock(productId, (long) threadCount, memberId);
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -285,7 +343,7 @@ class StockControllerTest extends AcceptedTest {
             long orderId = i;
             executorService.submit(() -> {
                 try {
-                    stockTestTemplate.deduct(productId, orderId, 1L);
+                    stockTestTemplate.deduct(productId, orderId, 1L, memberId);
                 } finally {
                     latch.countDown();
                 }
@@ -306,12 +364,15 @@ class StockControllerTest extends AcceptedTest {
 
         Long productId = 1L;
         Long addQuantity = 50L;
-        Stock stock = stockTestTemplate.createStock(productId, 100L);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+        Stock stock = stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
         AddStockRequest request = new AddStockRequest(productId, addQuantity);
+        String token = createTestJwtToken(memberId, Role.ROLES.SELLER);
 
         given()
             .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer " + token)
             .pathParam("productId", productId)
             .body(request)
             .consumeWith(document(
@@ -349,12 +410,15 @@ class StockControllerTest extends AcceptedTest {
 
         Long invalidProductId = 1L;
         Long addQuantity = 50L;
-        stockTestTemplate.createProductResponse(invalidProductId);
+        Long memberId = 10L;
+        stockTestTemplate.createProductResponse(invalidProductId, memberId);
         AddStockRequest request = new AddStockRequest(invalidProductId, addQuantity);
+        String token = createTestJwtToken(memberId, Role.ROLES.SELLER);
 
         ErrorResponse response =
             given()
                 .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + token)
                 .pathParam("productId", invalidProductId)
                 .body(request)
                 .consumeWith(document(
@@ -390,8 +454,9 @@ class StockControllerTest extends AcceptedTest {
         long productId = 1L;
         int threadCount = 10;
         long addQuantity = 5L;
+        Long memberId = 10L;
 
-        stockTestTemplate.createStock(productId, 0L);
+        stockTestTemplate.createStock(productId, 0L, memberId);
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -399,7 +464,7 @@ class StockControllerTest extends AcceptedTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
-                    stockTestTemplate.add(productId, addQuantity);
+                    stockTestTemplate.add(productId, addQuantity, memberId);
                 } finally {
                     latch.countDown();
                 }
@@ -416,15 +481,57 @@ class StockControllerTest extends AcceptedTest {
     }
 
     @Test
+    void 재고추가_소유자아님() {
+
+        Long productId = 1L;
+        Long addQuantity = 50L;
+        Long memberId = 10L;
+        Long forbiddenMemberId = 20L;
+        stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
+        AddStockRequest request = new AddStockRequest(productId, addQuantity);
+        String token = createTestJwtToken(forbiddenMemberId, Role.ROLES.SELLER);
+
+        ErrorResponse response = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer " + token)
+            .pathParam("productId", productId)
+            .body(request)
+            .consumeWith(document(
+                info()
+                    .tag("Stock")
+                    .summary("재고 추가")
+                    .description("상품 ID를 사용하여 재고를 추가합니다.")
+                    .pathParameters(
+                        parameterWithName("productId").description("상품 아이디")
+                    )
+                    .responseFields(
+                        field(ErrorResponse.class, "errorCode", "오류 코드"),
+                        field(ErrorResponse.class, "message", "오류 메시지")
+                    )
+            ))
+            .patch("/{productId}/stock/add")
+            .then()
+            .status(HttpStatus.FORBIDDEN)
+            .log().all()
+            .extract().body().as(ErrorResponse.class);
+
+        Assertions.assertThat(response.errorCode()).isEqualTo("stock.forbidden");
+        Assertions.assertThat(response.message()).isEqualTo("해당 상품에 대한 재고 관리 권한이 없습니다.");
+    }
+
+    @Test
     void 재고취소() {
 
         Long productId = 1L;
         Long orderId = 1L;
         Long deductQuantity = 30L;
         Long cancelQuantity = 30L;
-        Stock stock = stockTestTemplate.createStock(productId, 100L);
-        stockTestTemplate.deduct(productId, orderId, deductQuantity);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+
+        Stock stock = stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.deduct(productId, orderId, deductQuantity, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
 
         CancelStockRequest request = new CancelStockRequest(productId, orderId);
 
@@ -468,8 +575,10 @@ class StockControllerTest extends AcceptedTest {
 
         Long productId = 1L;
         Long invalidOrderId = 999L;
-        stockTestTemplate.createStock(productId, 100L);
-        stockTestTemplate.createProductResponse(productId);
+        Long memberId = 10L;
+
+        stockTestTemplate.createStock(productId, 100L, memberId);
+        stockTestTemplate.createProductResponse(productId, memberId);
 
         CancelStockRequest request = new CancelStockRequest(productId, invalidOrderId);
 
@@ -508,5 +617,8 @@ class StockControllerTest extends AcceptedTest {
         Assertions.assertThat(stock.quantity()).isEqualTo(100L);
     }
 
+    private String createTestJwtToken(Long memberId, String role) {
+        return TokenUtil.getSign(UserContext.of(memberId, role));
+    }
 
 }

--- a/src/test/java/site/ng_archive/ecom_stock/domain/stock/StockTestTemplate.java
+++ b/src/test/java/site/ng_archive/ecom_stock/domain/stock/StockTestTemplate.java
@@ -53,27 +53,27 @@ public class StockTestTemplate {
         }
     }
 
-    public Stock createStock(Long productId, Long quantity) {
-        createProductResponse(productId);
-        CreateStockCommand createStockCommand = new CreateStockCommand(productId, quantity);
+    public Stock createStock(Long productId, Long quantity, Long memberId) {
+        createProductResponse(productId, memberId);
+        CreateStockCommand createStockCommand = new CreateStockCommand(productId, quantity, memberId);
         return stockService.createStock(createStockCommand).block();
     }
 
-    public void createProductResponse(Long productId) {
+    public void createProductResponse(Long productId, Long memberId) {
         mockProductServer.enqueue(new MockResponse()
             .addHeader("Content-Type", "application/json")
-            .setBody(toJson(new ProductResponse(productId, "상품명", 20000L))));
+            .setBody(toJson(new ProductResponse(productId, "상품명", 20000L, memberId))));
     }
 
-    public Stock deduct(Long productId, Long orderId, Long deductQuantity) {
-        createProductResponse(productId);
+    public Stock deduct(Long productId, Long orderId, Long deductQuantity, Long memberId) {
+        createProductResponse(productId, memberId);
         DeductStockCommand deductStockCommand = new DeductStockCommand(productId, orderId, deductQuantity);
         return stockService.deductStock(deductStockCommand).block();
     }
 
-    public Stock add(Long productId, Long addQuantity) {
-        createProductResponse(productId);
-        AddStockCommand addStockCommand = new AddStockCommand(productId, addQuantity);
+    public Stock add(Long productId, Long addQuantity, Long memberId) {
+        createProductResponse(productId, memberId);
+        AddStockCommand addStockCommand = new AddStockCommand(productId, addQuantity, memberId);
         return stockService.addStock(addStockCommand).block();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 재고 생성 및 추가 작업에 사용자 인증 및 권한 검증 추가
  * 상품 소유자만 해당 상품의 재고를 관리할 수 있도록 제한

* **오류 메시지**
  * 권한 부족 시 새로운 오류 메시지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->